### PR TITLE
Use Node v12 and under buffer write.

### DIFF
--- a/lib/jobManager.js
+++ b/lib/jobManager.js
@@ -18,9 +18,9 @@ var ExtraNonceCounter = function(configInstanceId){
     var counter = instanceId << 27;
 
     this.next = function(){
-        var buff = new Buffer(32);
-        buff.writeUInt32BE(Math.abs(counter++), 0);
-        return buff.toString('hex')
+        var extraNonce = new Buffer(32);
+        extraNonce.writeUInt32BE(Math.abs(counter++), 0);
+        return extraNonce.toString('hex')
     };
 
     this.size = 32; //bytes

--- a/lib/jobManager.js
+++ b/lib/jobManager.js
@@ -18,9 +18,9 @@ var ExtraNonceCounter = function(configInstanceId){
     var counter = instanceId << 27;
 
     this.next = function(){
-        var extraNonce = Buffer(32);
-        Buffer.write(util.packUInt32BE(Math.abs(counter++)));
-        return extraNonce.toString('hex');
+        var buff = new Buffer(32);
+        buff.writeUInt32BE(Math.abs(counter++), 0);
+        return buff.toString('hex')
     };
 
     this.size = 32; //bytes


### PR DESCRIPTION
I was unable to run Buffer.write() in node v0.10.25 which is required I believe by the multi-hashing implementation that nomp is using. This uses the same buffer write in the util.js function to write in big endian the 32bit extra nonce to buffer.